### PR TITLE
FEAT: add list, update and delete operations for Mileages

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ System.out.println(response.getData()); // {}
 
 #### Mileage
 
+List `Mileage`s:
+
+```java
+String userId = "userId_506...";
+
+AboundBulkResponse<Mileage> response = abound.mileages().list(userId);
+
+System.out.println(response.getData()); // list of Mileages
+```
+
 Create `Mileage`s:
 
 ```java
@@ -220,6 +230,33 @@ String mileageId = "mileageId_4af...";
 AboundResponse<Mileage> response = abound.mileages().retrieve(userId, mileageId);
 
 System.out.println(response.getData().getDistance());
+```
+
+Update a `Mileage`:
+
+```java
+String userId = "userId_506...";
+String mileageId = "mileageId_4af...";
+MileageRequest mileageUpdates = MileageRequest.builder()
+  .distance(56.1)
+  .date("2021-08-04")
+  .description("Client visit")
+  .build();
+
+AboundResponse<Mileage> response = abound.mileages().update(userId, mileageId, mileageUpdates);
+
+System.out.println(response.getData().getDistance()); // 56.1
+```
+
+Delete a `Mileage`:
+
+```java
+String userId = "userId_506...";
+String mileageId = "mileageId_4af...";
+
+AboundResponse<EmptyJsonObject> response = abound.mileages().delete(userId, mileageId);
+
+System.out.println(response.getData()); // {}
 ```
 
 #### Payment Methods

--- a/src/main/java/com/withabound/resources/Mileages.java
+++ b/src/main/java/com/withabound/resources/Mileages.java
@@ -6,6 +6,7 @@ import com.withabound.models.mileages.MileageRequest;
 import com.withabound.resources.base.AboundBulkResponse;
 import com.withabound.resources.base.AboundResponse;
 import com.withabound.resources.base.AboundUserScopedResource;
+import com.withabound.resources.base.EmptyJsonObject;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -22,6 +23,10 @@ public class Mileages extends AboundUserScopedResource<MileageRequest, Mileage> 
     return "/mileage";
   }
 
+  public AboundBulkResponse<Mileage> list(final String userId) throws IOException {
+    return super.listForUser(userId);
+  }
+
   public AboundBulkResponse<Mileage> create(
       final String userId, final List<MileageRequest> toCreate) throws IOException {
     final Map<String, List<MileageRequest>> requestPayload =
@@ -33,5 +38,19 @@ public class Mileages extends AboundUserScopedResource<MileageRequest, Mileage> 
   public AboundResponse<Mileage> retrieve(final String userId, final String mileageId)
       throws IOException {
     return super.retrieveForUser(userId, mileageId);
+  }
+
+  public AboundResponse<Mileage> update(
+      final String userId, final String mileageId, final MileageRequest toUpdate)
+      throws IOException {
+    final Map<String, MileageRequest> requestPayload =
+        Collections.singletonMap("mileage", toUpdate);
+
+    return super.updateForUser(userId, mileageId, requestPayload);
+  }
+
+  public AboundResponse<EmptyJsonObject> delete(final String userId, final String mileageId)
+      throws IOException {
+    return super.deleteForUser(userId, mileageId);
   }
 }

--- a/src/test/java/com/withabound/resources/IncomesTest.java
+++ b/src/test/java/com/withabound/resources/IncomesTest.java
@@ -37,10 +37,13 @@ public class IncomesTest extends AbstractAboundTest {
     AboundBulkResponseAssert.assertThat(response).hasResponseMetadata();
 
     final List<Income> listed = response.getData();
-    assertThat(listed).hasSize(1);
+    assertThat(listed).hasSize(2);
 
-    final Income income = listed.get(0);
-    IncomeAssert.assertThat(income).isDesignServicesClientInvoice();
+    final Income first = listed.get(0);
+    IncomeAssert.assertThat(first).isDesignServicesClientInvoice();
+
+    final Income second = listed.get(1);
+    IncomeAssert.assertThat(second).isDesignServicesSSA1099ClientInvoice();
   }
 
   @Test

--- a/src/test/java/com/withabound/resources/MileagesTest.java
+++ b/src/test/java/com/withabound/resources/MileagesTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -99,11 +100,15 @@ public class MileagesTest extends AbstractAboundTest {
 
   @Test
   public void testUpdate() throws IOException {
+    final double newDistance = TestUtils.randomDouble();
+    final String newDescription = TestUtils.randomAlphabetic();
+    final String newDate = TestUtils.randomDate();
+
     final MileageRequest mileageUpdates =
         MileageRequest.builder()
-            .distance(TestUtils.randomDouble())
-            .description(TestUtils.randomAlphabetic())
-            .date(TestUtils.randomDate())
+            .distance(newDistance)
+            .description(newDescription)
+            .date(newDate)
             .build();
 
     final AboundResponse<Mileage> response =
@@ -114,7 +119,9 @@ public class MileagesTest extends AbstractAboundTest {
     AboundResponseAssert.assertThat(response).hasResponseMetadata();
 
     final Mileage updated = response.getData();
-    MileageAssert.assertThat(updated).is09Jan2020OnSiteClientVisit();
+    assertThat(updated.getDistance()).isEqualTo(newDistance);
+    assertThat(updated.getDescription()).isEqualTo(Optional.of(newDescription));
+    assertThat(updated.getDate()).isEqualTo(newDate);
   }
 
   @Test

--- a/src/test/java/com/withabound/resources/MileagesTest.java
+++ b/src/test/java/com/withabound/resources/MileagesTest.java
@@ -11,6 +11,7 @@ import com.withabound.resources.asserts.AboundResponseAssert;
 import com.withabound.resources.asserts.MileageAssert;
 import com.withabound.resources.base.AboundBulkResponse;
 import com.withabound.resources.base.AboundResponse;
+import com.withabound.resources.base.EmptyJsonObject;
 import com.withabound.util.TestUtils;
 import java.io.IOException;
 import java.util.Arrays;
@@ -21,6 +22,19 @@ import org.junit.jupiter.api.Test;
 
 public class MileagesTest extends AbstractAboundTest {
   public static final String TEST_MILEAGE_ID = "mileageId_test4af7070cfb04a12552a1950e2f0afa660fba";
+
+  @Test
+  public void testList() throws IOException {
+    final AboundBulkResponse<Mileage> listed =
+        getAboundClient().mileages().list(TestUtils.TEST_USER_ID);
+
+    AboundBulkResponseAssert.assertThat(listed).hasResponseMetadata();
+
+    assertThat(listed.getData()).hasSize(1);
+
+    final Mileage mileage = listed.getData().get(0);
+    MileageAssert.assertThat(mileage).is09Jan2020OnSiteClientVisit();
+  }
 
   @Test
   public void testCreate() throws IOException {
@@ -81,5 +95,33 @@ public class MileagesTest extends AbstractAboundTest {
     final Mileage retrieved = response.getData();
 
     MileageAssert.assertThat(retrieved).is09Jan2020OnSiteClientVisit();
+  }
+
+  @Test
+  public void testUpdate() throws IOException {
+    final MileageRequest mileageUpdates =
+        MileageRequest.builder()
+            .distance(TestUtils.randomDouble())
+            .description(TestUtils.randomAlphabetic())
+            .date(TestUtils.randomDate())
+            .build();
+
+    final AboundResponse<Mileage> response =
+        getAboundClient()
+            .mileages()
+            .update(TestUtils.TEST_USER_ID, TEST_MILEAGE_ID, mileageUpdates);
+
+    AboundResponseAssert.assertThat(response).hasResponseMetadata();
+
+    final Mileage updated = response.getData();
+    MileageAssert.assertThat(updated).is09Jan2020OnSiteClientVisit();
+  }
+
+  @Test
+  public void testDelete() throws IOException {
+    final AboundResponse<EmptyJsonObject> response =
+        getAboundClient().mileages().delete(TestUtils.TEST_USER_ID, TEST_MILEAGE_ID);
+
+    AboundResponseAssert.assertThat(response).hasResponseMetadata().hasEmptyDataObject();
   }
 }

--- a/src/test/java/com/withabound/resources/asserts/IncomeAssert.java
+++ b/src/test/java/com/withabound/resources/asserts/IncomeAssert.java
@@ -1,6 +1,7 @@
 package com.withabound.resources.asserts;
 
 import com.withabound.models.incomes.Income;
+import com.withabound.models.incomes.IncomeDocumentType;
 import com.withabound.models.incomes.IncomeType;
 import com.withabound.resources.IncomesTest;
 import java.util.Optional;
@@ -18,6 +19,21 @@ public class IncomeAssert extends AbstractAssert<IncomeAssert, Income> {
     Assertions.assertThat(actual.getIncomeType()).isEqualTo(IncomeType.TEN99);
     Assertions.assertThat(actual.getAmount()).isEqualTo(222.34);
     Assertions.assertThat(actual.getDate()).isEqualTo("2020-01-14");
+    Assertions.assertThat(actual.getDescription()).isEqualTo(Optional.of("Client Invoice"));
+    Assertions.assertThat(actual.getCategory()).isEqualTo(Optional.of("Design Services"));
+    Assertions.assertThat(actual.getForeignId()).isEqualTo(Optional.of("your_foreign_id"));
+
+    return this;
+  }
+
+  public IncomeAssert isDesignServicesSSA1099ClientInvoice() {
+    Assertions.assertThat(actual).isNotNull();
+    Assertions.assertThat(actual.getIncomeId()).isEqualTo(IncomesTest.TEST_INCOME_ID);
+    Assertions.assertThat(actual.getIncomeType()).isEqualTo(IncomeType.TEN99);
+    Assertions.assertThat(actual.getAmount()).isEqualTo(333.34);
+    Assertions.assertThat(actual.getDate()).isEqualTo("2020-01-14");
+    Assertions.assertThat(actual.getDocumentType())
+        .isEqualTo(Optional.of(IncomeDocumentType.SSA1099));
     Assertions.assertThat(actual.getDescription()).isEqualTo(Optional.of("Client Invoice"));
     Assertions.assertThat(actual.getCategory()).isEqualTo(Optional.of("Design Services"));
     Assertions.assertThat(actual.getForeignId()).isEqualTo(Optional.of("your_foreign_id"));


### PR DESCRIPTION
This PR adds 3 new operations for Mileages, accompanying README documentation, and tests.